### PR TITLE
Explain that users should look elsewhere for timetables

### DIFF
--- a/app/views/shared/_location_content.erb
+++ b/app/views/shared/_location_content.erb
@@ -13,3 +13,23 @@
 <%- else %>
   <%= t('shared.location_content.no_problems')%>
 <%- end %>
+
+<h3 class="location-content-header">Timetables</h3>
+
+<%- transport_mode_names = location.transport_modes.map { |tm| tm.name }
+    timetable_link = nil
+    if transport_mode_names.include? 'Bus'
+        timetable_link = '<a href="http://traveline.info/">Traveline</a>'
+    elsif transport_mode_names.include? 'Train'
+        timetable_link = '<a href="http://www.nationalrail.co.uk">National Rail Enquiries</a>'
+    end
+    timetable_explanation = t('shared.location_content.timetable_preamble')
+    if timetable_link
+        timetable_explanation += t('shared.location_content.timetable_alternative', :timetable_link => timetable_link)
+    end
+-%>
+
+<p><%= raw(timetable_explanation) %>.
+   <%= raw(t('shared.location_content.generic_journey_planning',
+           :generic_journey_planning_link => '<a href="http://www.transportdirect.info">TransportDirect</a>')) %>
+</p>

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -88,6 +88,9 @@ en:
       metro_route_explanation: "Overcrowding? Fare or ticket problems? Report a problem on this route%{orgs}"
       stop_explanation: "Broken glass? Missing timetable? Report a problem at this %{location}%{orgs}"
       station_explanation: "Poor %{location} facilities? Access problems? Report a problem at this %{location}%{orgs}"
+      timetable_preamble: "FixMyTransport is a site aimed primarily at reporting problems on public transport. We provide maps to make that easier, but for up-to-date timetabling and detailed route information, you should use the operator's website"
+      timetable_alternative: " or %{timetable_link}"
+      generic_journey_planning: "For planning journeys, you may find %{generic_journey_planning_link} useful."
     login:
       a_fixmytransport_boffin: "a FixMyTransport boffin"
       must_be_logged_out: "You must be logged out to access this page"


### PR DESCRIPTION
The idea here is to (a) be helpful to users and (b) reduce
the amount of mail we get asking for timetables.

This version suggests Traveline for bus timetables,
Nation Rail Enquiries for trains, and TransportDirect
in every case.
